### PR TITLE
Fixing helm instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ services:
 Requires building the images first, see the quickstart for Docker section.
 
 - Set your Kubernetes context so you're pointing to a Kubernetes environment.
-- `helm install --name mongo --set usePassword=false,replicaSet.enabled=true,service.type=LoadBalancer,replicaSet.replicas.secondary=3 stable/mongodb`
-- `helm install --name backend backend/chart/backend`
-- `helm install --name frontend frontend/chart/frontend`
+- `helm repo add bitnami https://charts.bitnami.com/bitnami`
+- `helm install mongo --set usePassword=false,replicaSet.enabled=true,service.type=LoadBalancer,replicaSet.replicas.secondary=3 bitnami/mongodb`
+- `helm install backend backend/chart/backend`
+- `helm install frontend frontend/chart/frontend`


### PR DESCRIPTION
Updating the helm instructions to correspond to helm v3.

@BethGriggs @lholmquist for people that use minikube (like me) instead of k8s from docker-desktop there are extra steps to make everything work (because minikube does not have by default access to docker's local registry, etc).

Do we want to add a side-section with some steps on how to make everything work with minikube ??